### PR TITLE
Add test to ensure decryption fails with incorrect key

### DIFF
--- a/tests/crypto_test.go
+++ b/tests/crypto_test.go
@@ -39,3 +39,19 @@ func TestEmojiEncoding(t *testing.T) {
 		t.Errorf("expected %v, got %v", data, decoded)
 	}
 }
+
+func TestDecryptWithWrongKeyFails(t *testing.T) {
+	keyA := "secret-key-a"
+	keyB := "secret-key-b"
+	data := []byte("hello world")
+
+	encrypted, err := crypto.Encrypt(data, keyA)
+	if err != nil {
+		t.Fatalf("failed to encrypt: %v", err)
+	}
+
+	decrypted, err := crypto.Decrypt(encrypted, keyB)
+	if err == nil {
+		t.Fatalf("expected decrypt to fail with wrong key, got data: %v", decrypted)
+	}
+}


### PR DESCRIPTION
test(crypto): This PR ensure decrypt fails with wrong key  Add a negative test case to verify that ciphertext encrypted with one key cannot be decrypted using a different key.  This strengthens crypto safety guarantees and prevents silent data corruption or misuse.

Note: when running the full test suite locally, I observed some failures in existing DB/storage tests related to filesystem path and persistence assumptions. These appear unrelated to this crypto-only change.